### PR TITLE
Allow rgen 0.10.x

### DIFF
--- a/openvox-strings.gemspec
+++ b/openvox-strings.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |s|
   s.files = Dir['CHANGELOG.md', 'README.md', 'LICENSE', 'lib/**/*', 'exe/**/*']
 
   s.add_dependency 'openvox', '>= 7', '< 9'
-  s.add_dependency 'rgen', '~> 0.9'
+  s.add_dependency 'rgen', '>= 0.9', '< 0.11'
   s.add_dependency 'yard', '~> 0.9'
 end


### PR DESCRIPTION
Version 0.10.0 added support for Ruby 3.0, 3.1, 3.2.  Staying with 0.9.0
might be adventurous.

ChangeLog:
https://github.com/mthiede/rgen/blob/master/CHANGELOG#L234
