### PR TITLE
Add Hiera defaults support for module documentation

### DIFF
--- a/lib/openvox-strings/hiera.rb
+++ b/lib/openvox-strings/hiera.rb
@@ -95,17 +95,17 @@ module OpenvoxStrings
         # Puppet undef
         'undef'
       when Hash
-        # Convert hash to Puppet hash syntax
+        # Convert hash to Puppet hash syntax (no spaces to match code defaults format)
         return '{}' if value.empty?
 
         pairs = value.map { |k, v| "'#{k}' => #{value_to_puppet_string(v)}" }
         "{ #{pairs.join(', ')} }"
       when Array
-        # Convert array to Puppet array syntax
+        # Convert array to Puppet array syntax (no spaces to match code defaults format)
         return '[]' if value.empty?
 
         elements = value.map { |v| value_to_puppet_string(v) }
-        "[ #{elements.join(', ')} ]"
+        "[#{elements.join(', ')}]"
       else
         # Fallback: convert to string and quote
         "'#{value}'"

--- a/lib/openvox-strings/hiera.rb
+++ b/lib/openvox-strings/hiera.rb
@@ -96,10 +96,14 @@ module OpenvoxStrings
         'undef'
       when Hash
         # Convert hash to Puppet hash syntax
+        return '{}' if value.empty?
+
         pairs = value.map { |k, v| "'#{k}' => #{value_to_puppet_string(v)}" }
         "{ #{pairs.join(', ')} }"
       when Array
         # Convert array to Puppet array syntax
+        return '[]' if value.empty?
+
         elements = value.map { |v| value_to_puppet_string(v) }
         "[ #{elements.join(', ')} ]"
       else

--- a/lib/openvox-strings/hiera.rb
+++ b/lib/openvox-strings/hiera.rb
@@ -85,11 +85,8 @@ module OpenvoxStrings
 
         # Strings should be quoted
         "'#{value}'"
-      when Integer, Float
-        # Numbers are unquoted
-        value.to_s
-      when TrueClass, FalseClass
-        # Booleans are lowercase
+      when Integer, Float, TrueClass, FalseClass
+        # Numbers and booleans are unquoted/lowercase
         value.to_s
       when NilClass, :undef
         # Puppet undef

--- a/lib/openvox-strings/hiera.rb
+++ b/lib/openvox-strings/hiera.rb
@@ -72,7 +72,7 @@ module OpenvoxStrings
         next false unless path
 
         # Check if path contains interpolations like %{...}
-        !path.match?(/%\{[^}]+\}/)
+        !path.include?('%{')
       end
 
       return nil unless first_static

--- a/lib/openvox-strings/hiera.rb
+++ b/lib/openvox-strings/hiera.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+require 'yaml'
+
+module OpenvoxStrings
+  # Parser for Hiera configuration and data
+  class Hiera
+    attr_reader :hiera_config, :common_data
+
+    # Initializes a Hiera parser for a given module path
+    # @param [String] module_path The path to the Puppet module root directory
+    def initialize(module_path)
+      @module_path = module_path
+      @hiera_config = load_hiera_config
+      @common_data = load_common_data
+    end
+
+    # Checks if Hiera is configured for this module
+    # @return [Boolean] true if hiera.yaml exists and is valid
+    def hiera_enabled?
+      !@hiera_config.nil?
+    end
+
+    # Gets the default value for a parameter from Hiera data
+    # @param [String] class_name The fully qualified class name (e.g., 'github_actions_runner')
+    # @param [String] param_name The parameter name
+    # @return [String, nil] The default value as a string, or nil if not found
+    def lookup_default(class_name, param_name)
+      return nil unless hiera_enabled?
+      return nil if @common_data.nil?
+
+      # Try to lookup with class prefix: modulename::parametername
+      key = "#{class_name}::#{param_name}"
+      return nil unless @common_data.key?(key)
+
+      value = @common_data[key]
+
+      # Convert value to Puppet-compatible string representation
+      value_to_puppet_string(value)
+    end
+
+    private
+
+    # Loads and parses hiera.yaml from the module root
+    # @return [Hash, nil] The parsed hiera configuration, or nil if not found/invalid
+    def load_hiera_config
+      hiera_file = File.join(@module_path, 'hiera.yaml')
+      return nil unless File.exist?(hiera_file)
+
+      begin
+        YAML.load_file(hiera_file)
+      rescue StandardError => e
+        YARD::Logger.instance.warn "Failed to parse hiera.yaml: #{e.message}"
+        nil
+      end
+    end
+
+    # Loads and parses data/common.yaml from the module
+    # @return [Hash, nil] The parsed common data, or nil if not found/invalid
+    def load_common_data
+      return nil unless hiera_enabled?
+
+      # Get datadir from hiera config (defaults to 'data')
+      datadir = @hiera_config.dig('defaults', 'datadir') || 'data'
+      common_file = File.join(@module_path, datadir, 'common.yaml')
+
+      return nil unless File.exist?(common_file)
+
+      begin
+        YAML.load_file(common_file)
+      rescue StandardError => e
+        YARD::Logger.instance.warn "Failed to parse common.yaml: #{e.message}"
+        nil
+      end
+    end
+
+    # Converts a Ruby value to a Puppet-compatible string representation
+    # @param [Object] value The value to convert
+    # @return [String] The Puppet-compatible string representation
+    def value_to_puppet_string(value)
+      case value
+      when String
+        # Empty strings from YAML nil (~) should be undef
+        return 'undef' if value.empty?
+
+        # Strings should be quoted
+        "'#{value}'"
+      when Integer, Float
+        # Numbers are unquoted
+        value.to_s
+      when TrueClass, FalseClass
+        # Booleans are lowercase
+        value.to_s
+      when NilClass, :undef
+        # Puppet undef
+        'undef'
+      when Hash
+        # Convert hash to Puppet hash syntax
+        pairs = value.map { |k, v| "'#{k}' => #{value_to_puppet_string(v)}" }
+        "{ #{pairs.join(', ')} }"
+      when Array
+        # Convert array to Puppet array syntax
+        elements = value.map { |v| value_to_puppet_string(v) }
+        "[ #{elements.join(', ')} ]"
+      else
+        # Fallback: convert to string and quote
+        "'#{value}'"
+      end
+    end
+  end
+end

--- a/lib/openvox-strings/markdown/base.rb
+++ b/lib/openvox-strings/markdown/base.rb
@@ -244,23 +244,12 @@ module OpenvoxStrings::Markdown
     # @param [String] file_path The path to a file in the module
     # @return [String, nil] The module root path or nil if not found
     def find_module_root(file_path)
-      current_path = File.dirname(File.expand_path(file_path))
-
-      # Walk up the directory tree looking for module indicators
-      10.times do
-        # Check if this looks like a module root (has manifests/, lib/, or hiera.yaml)
-        if File.exist?(File.join(current_path, 'hiera.yaml')) ||
-           (File.exist?(File.join(current_path, 'manifests')) && File.exist?(File.join(current_path, 'metadata.json')))
-          return current_path
-        end
-
-        parent = File.dirname(current_path)
-        break if parent == current_path # Reached filesystem root
-
-        current_path = parent
+    names = %w[metadata.json manifests hiera.yaml]
+    Pathname.new(file_path).expand_path.parent.ascend do |current_path|
+      names.each do |name|
+        return current_path if (current_path / name).exist?
       end
-
-      nil
+    end
     end
 
     # Merges code defaults with Hiera defaults

--- a/lib/openvox-strings/markdown/base.rb
+++ b/lib/openvox-strings/markdown/base.rb
@@ -244,12 +244,12 @@ module OpenvoxStrings::Markdown
     # @param [String] file_path The path to a file in the module
     # @return [String, nil] The module root path or nil if not found
     def find_module_root(file_path)
-    names = %w[metadata.json manifests hiera.yaml]
-    Pathname.new(file_path).expand_path.parent.ascend do |current_path|
-      names.each do |name|
-        return current_path if (current_path / name).exist?
+      names = %w[metadata.json manifests hiera.yaml]
+      Pathname.new(file_path).expand_path.parent.ascend do |current_path|
+        names.each do |name|
+          return current_path if (current_path / name).exist?
+        end
       end
-    end
     end
 
     # Merges code defaults with Hiera defaults

--- a/spec/unit/openvox-strings/hiera_spec.rb
+++ b/spec/unit/openvox-strings/hiera_spec.rb
@@ -1,0 +1,202 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'openvox-strings/hiera'
+require 'tmpdir'
+require 'fileutils'
+
+describe OpenvoxStrings::Hiera do
+  let(:temp_dir) { Dir.mktmpdir }
+
+  after do
+    FileUtils.remove_entry(temp_dir)
+  end
+
+  describe '#initialize' do
+    context 'when hiera.yaml exists' do
+      before do
+        File.write(File.join(temp_dir, 'hiera.yaml'), <<~YAML)
+          version: 5
+          defaults:
+            datadir: data
+            data_hash: yaml_data
+          hierarchy:
+            - name: "Common defaults"
+              path: "common.yaml"
+        YAML
+      end
+
+      it 'loads hiera configuration' do
+        hiera = described_class.new(temp_dir)
+        expect(hiera.hiera_config).not_to be_nil
+        expect(hiera.hiera_config['version']).to eq(5)
+      end
+
+      it 'is enabled' do
+        hiera = described_class.new(temp_dir)
+        expect(hiera).to be_hiera_enabled
+      end
+    end
+
+    context 'when hiera.yaml does not exist' do
+      it 'is not enabled' do
+        hiera = described_class.new(temp_dir)
+        expect(hiera).not_to be_hiera_enabled
+      end
+    end
+  end
+
+  describe '#load_common_data' do
+    context 'when common.yaml exists' do
+      before do
+        File.write(File.join(temp_dir, 'hiera.yaml'), <<~YAML)
+          version: 5
+          defaults:
+            datadir: data
+            data_hash: yaml_data
+          hierarchy:
+            - name: "Common defaults"
+              path: "common.yaml"
+        YAML
+
+        FileUtils.mkdir_p(File.join(temp_dir, 'data'))
+        File.write(File.join(temp_dir, 'data', 'common.yaml'), <<~YAML)
+          testmodule::param1: 'value1'
+          testmodule::param2: 42
+          testmodule::param3: true
+          testmodule::param4: ~
+        YAML
+      end
+
+      it 'loads common data' do
+        hiera = described_class.new(temp_dir)
+        expect(hiera.common_data).not_to be_nil
+        expect(hiera.common_data['testmodule::param1']).to eq('value1')
+      end
+    end
+  end
+
+  describe '#lookup_default' do
+    before do
+      File.write(File.join(temp_dir, 'hiera.yaml'), <<~YAML)
+        version: 5
+        defaults:
+          datadir: data
+          data_hash: yaml_data
+        hierarchy:
+          - name: "Common defaults"
+            path: "common.yaml"
+      YAML
+
+      FileUtils.mkdir_p(File.join(temp_dir, 'data'))
+      File.write(File.join(temp_dir, 'data', 'common.yaml'), <<~YAML)
+        circus::tent_size: 'large'
+        circus::location: '/opt/circus-ground'
+        circus::season: '2025'
+        circus::ringmaster: 'Giovanni'
+        circus::has_animals: false
+        circus::performers: {}
+        circus::insurance_policy: ~
+      YAML
+    end
+
+    let(:hiera) { described_class.new(temp_dir) }
+
+    it 'returns string values with quotes' do
+      result = hiera.lookup_default('circus', 'tent_size')
+      expect(result).to eq("'large'")
+    end
+
+    it 'returns string paths with quotes' do
+      result = hiera.lookup_default('circus', 'location')
+      expect(result).to eq("'/opt/circus-ground'")
+    end
+
+    it 'returns string version numbers with quotes' do
+      result = hiera.lookup_default('circus', 'season')
+      expect(result).to eq("'2025'")
+    end
+
+    it 'returns string names with quotes' do
+      result = hiera.lookup_default('circus', 'ringmaster')
+      expect(result).to eq("'Giovanni'")
+    end
+
+    it 'returns boolean false as false' do
+      result = hiera.lookup_default('circus', 'has_animals')
+      expect(result).to eq('false')
+    end
+
+    it 'returns empty hash as {}' do
+      result = hiera.lookup_default('circus', 'performers')
+      expect(result).to eq('{  }')
+    end
+
+    it 'returns nil/undef as undef' do
+      result = hiera.lookup_default('circus', 'insurance_policy')
+      expect(result).to eq('undef')
+    end
+
+    it 'returns nil for non-existent keys' do
+      result = hiera.lookup_default('circus', 'nonexistent')
+      expect(result).to be_nil
+    end
+
+    it 'returns nil for wrong class name' do
+      result = hiera.lookup_default('wrong_module', 'tent_size')
+      expect(result).to be_nil
+    end
+  end
+
+  describe '#value_to_puppet_string' do
+    let(:hiera) { described_class.new(temp_dir) }
+
+    it 'converts strings with quotes' do
+      expect(hiera.send(:value_to_puppet_string, 'hello')).to eq("'hello'")
+    end
+
+    it 'converts integers without quotes' do
+      expect(hiera.send(:value_to_puppet_string, 42)).to eq('42')
+    end
+
+    it 'converts floats without quotes' do
+      expect(hiera.send(:value_to_puppet_string, 3.14)).to eq('3.14')
+    end
+
+    it 'converts true to lowercase true' do
+      expect(hiera.send(:value_to_puppet_string, true)).to eq('true')
+    end
+
+    it 'converts false to lowercase false' do
+      expect(hiera.send(:value_to_puppet_string, false)).to eq('false')
+    end
+
+    it 'converts nil to undef' do
+      expect(hiera.send(:value_to_puppet_string, nil)).to eq('undef')
+    end
+
+    it 'converts empty arrays' do
+      expect(hiera.send(:value_to_puppet_string, [])).to eq('[  ]')
+    end
+
+    it 'converts arrays with values' do
+      expect(hiera.send(:value_to_puppet_string, ['a', 'b'])).to eq("[ 'a', 'b' ]")
+    end
+
+    it 'converts empty hashes' do
+      expect(hiera.send(:value_to_puppet_string, {})).to eq('{  }')
+    end
+
+    it 'converts hashes with values' do
+      result = hiera.send(:value_to_puppet_string, { 'key' => 'value' })
+      expect(result).to eq("{ 'key' => 'value' }")
+    end
+
+    it 'converts nested structures' do
+      nested = { 'array' => [1, 2], 'nested_hash' => { 'key' => 'value' } }
+      result = hiera.send(:value_to_puppet_string, nested)
+      expect(result).to include("'array' => [ 1, 2 ]")
+      expect(result).to include("'nested_hash' => { 'key' => 'value' }")
+    end
+  end
+end

--- a/spec/unit/openvox-strings/hiera_spec.rb
+++ b/spec/unit/openvox-strings/hiera_spec.rb
@@ -198,5 +198,28 @@ describe OpenvoxStrings::Hiera do
       expect(result).to include("'array' => [1, 2]")
       expect(result).to include("'nested_hash' => { 'key' => 'value' }")
     end
+
+    it 'formats arrays without spaces to match code defaults' do
+      # Arrays must use ['a', 'b'] not [ 'a', 'b' ] to match puppet-strings code format
+      result = hiera.send(:value_to_puppet_string, ['alpha', 'beta', 'gamma'])
+      expect(result).to eq("['alpha', 'beta', 'gamma']")
+      expect(result).not_to include('[ ')
+      expect(result).not_to include(' ]')
+    end
+
+    it 'formats integer arrays without spaces to match code defaults' do
+      result = hiera.send(:value_to_puppet_string, [1, 2, 3, 5, 8])
+      expect(result).to eq('[1, 2, 3, 5, 8]')
+      expect(result).not_to include('[ ')
+      expect(result).not_to include(' ]')
+    end
+
+    it 'formats nested arrays in hashes without spaces' do
+      nested = { 'tags' => ['prod', 'eu'] }
+      result = hiera.send(:value_to_puppet_string, nested)
+      expect(result).to eq("{ 'tags' => ['prod', 'eu'] }")
+      expect(result).not_to include('[ ')
+      expect(result).not_to include(' ]')
+    end
   end
 end

--- a/spec/unit/openvox-strings/hiera_spec.rb
+++ b/spec/unit/openvox-strings/hiera_spec.rb
@@ -69,6 +69,7 @@ describe OpenvoxStrings::Hiera do
 
     context 'when hierarchy contains interpolations before static layer' do
       before do
+        # rubocop:disable Style/FormatStringToken
         File.write(File.join(temp_dir, 'hiera.yaml'), <<~YAML)
           version: 5
           defaults:
@@ -82,6 +83,7 @@ describe OpenvoxStrings::Hiera do
             - name: "Common defaults"
               path: "common.yaml"
         YAML
+        # rubocop:enable Style/FormatStringToken
       end
 
       it 'skips layers with interpolations and returns first static layer' do
@@ -93,6 +95,7 @@ describe OpenvoxStrings::Hiera do
 
     context 'when only interpolated layers exist' do
       before do
+        # rubocop:disable Style/FormatStringToken
         File.write(File.join(temp_dir, 'hiera.yaml'), <<~YAML)
           version: 5
           defaults:
@@ -104,6 +107,7 @@ describe OpenvoxStrings::Hiera do
             - name: "Per-environment data"
               path: "env/%{environment}.yaml"
         YAML
+        # rubocop:enable Style/FormatStringToken
       end
 
       it 'returns nil' do
@@ -205,7 +209,7 @@ describe OpenvoxStrings::Hiera do
     context 'when file contains invalid YAML' do
       before do
         FileUtils.mkdir_p(File.join(temp_dir, 'data'))
-        File.write(File.join(temp_dir, 'data', 'invalid.yaml'), "invalid: yaml: content: [")
+        File.write(File.join(temp_dir, 'data', 'invalid.yaml'), 'invalid: yaml: content: [')
       end
 
       it 'returns nil and logs warning' do

--- a/spec/unit/openvox-strings/hiera_spec.rb
+++ b/spec/unit/openvox-strings/hiera_spec.rb
@@ -180,7 +180,7 @@ describe OpenvoxStrings::Hiera do
     end
 
     it 'converts arrays with values' do
-      expect(hiera.send(:value_to_puppet_string, ['a', 'b'])).to eq("[ 'a', 'b' ]")
+      expect(hiera.send(:value_to_puppet_string, ['a', 'b'])).to eq("['a', 'b']")
     end
 
     it 'converts empty hashes' do
@@ -195,7 +195,7 @@ describe OpenvoxStrings::Hiera do
     it 'converts nested structures' do
       nested = { 'array' => [1, 2], 'nested_hash' => { 'key' => 'value' } }
       result = hiera.send(:value_to_puppet_string, nested)
-      expect(result).to include("'array' => [ 1, 2 ]")
+      expect(result).to include("'array' => [1, 2]")
       expect(result).to include("'nested_hash' => { 'key' => 'value' }")
     end
   end

--- a/spec/unit/openvox-strings/hiera_spec.rb
+++ b/spec/unit/openvox-strings/hiera_spec.rb
@@ -129,7 +129,7 @@ describe OpenvoxStrings::Hiera do
 
     it 'returns empty hash as {}' do
       result = hiera.lookup_default('circus', 'performers')
-      expect(result).to eq('{  }')
+      expect(result).to eq('{}')
     end
 
     it 'returns nil/undef as undef' do
@@ -176,7 +176,7 @@ describe OpenvoxStrings::Hiera do
     end
 
     it 'converts empty arrays' do
-      expect(hiera.send(:value_to_puppet_string, [])).to eq('[  ]')
+      expect(hiera.send(:value_to_puppet_string, [])).to eq('[]')
     end
 
     it 'converts arrays with values' do
@@ -184,7 +184,7 @@ describe OpenvoxStrings::Hiera do
     end
 
     it 'converts empty hashes' do
-      expect(hiera.send(:value_to_puppet_string, {})).to eq('{  }')
+      expect(hiera.send(:value_to_puppet_string, {})).to eq('{}')
     end
 
     it 'converts hashes with values' do

--- a/spec/unit/openvox-strings/hiera_spec.rb
+++ b/spec/unit/openvox-strings/hiera_spec.rb
@@ -180,7 +180,7 @@ describe OpenvoxStrings::Hiera do
     end
 
     it 'converts arrays with values' do
-      expect(hiera.send(:value_to_puppet_string, ['a', 'b'])).to eq("['a', 'b']")
+      expect(hiera.send(:value_to_puppet_string, %w[a b])).to eq("['a', 'b']")
     end
 
     it 'converts empty hashes' do
@@ -201,7 +201,7 @@ describe OpenvoxStrings::Hiera do
 
     it 'formats arrays without spaces to match code defaults' do
       # Arrays must use ['a', 'b'] not [ 'a', 'b' ] to match puppet-strings code format
-      result = hiera.send(:value_to_puppet_string, ['alpha', 'beta', 'gamma'])
+      result = hiera.send(:value_to_puppet_string, %w[alpha beta gamma])
       expect(result).to eq("['alpha', 'beta', 'gamma']")
       expect(result).not_to include('[ ')
       expect(result).not_to include(' ]')
@@ -215,7 +215,7 @@ describe OpenvoxStrings::Hiera do
     end
 
     it 'formats nested arrays in hashes without spaces' do
-      nested = { 'tags' => ['prod', 'eu'] }
+      nested = { 'tags' => %w[prod eu] }
       result = hiera.send(:value_to_puppet_string, nested)
       expect(result).to eq("{ 'tags' => ['prod', 'eu'] }")
       expect(result).not_to include('[ ')


### PR DESCRIPTION
## Summary

This PR adds support for reading parameter defaults from Hiera data files (`data/common.yaml`) when generating module documentation with openvox-strings.

Previously, openvox-strings could only document parameter defaults that were explicitly defined in Puppet code. With this feature, defaults can now be maintained in Hiera data files while still appearing correctly in the generated REFERENCE.md documentation.

## Motivation

Many Puppet modules use Hiera for default values to enable easier customization and separation of data from code. However, this created a documentation gap - parameters without code defaults wouldn't show any default value in the generated documentation, even though they had defaults in `data/common.yaml`.

## Implementation

### Core Changes

1. **New `OpenvoxStrings::Hiera` class** (`lib/openvox-strings/hiera.rb`)
   - Parses `hiera.yaml` configuration
   - Loads data from `data/common.yaml`
   - Provides `lookup_default(class_name, param_name)` method
   - Converts Ruby values to Puppet-compatible string representation

2. **Integration in `OpenvoxStrings::Markdown::Base`** (`lib/openvox-strings/markdown/base.rb`)
   - Modified `defaults` method to merge code defaults with Hiera defaults
   - Code defaults take precedence (backwards compatible)
   - Automatically detects module root from manifest file paths
   - Only activates when `hiera.yaml` exists

### Key Features

- ✅ **Backwards compatible**: Code defaults always take precedence over Hiera defaults
- ✅ **Zero configuration**: Automatically detects and uses Hiera if `hiera.yaml` exists
- ✅ **All data types supported**: String, Integer, Float, Boolean, Array, Hash, nil/undef, nested structures
- ✅ **Exact formatting match**: Output is byte-for-byte identical to code defaults format

### Data Type Conversions

The implementation correctly handles all Puppet data types:
- Strings: `'value'` (quoted)
- Numbers: `42`, `3.14` (unquoted)
- Booleans: `true`, `false` (lowercase, unquoted)
- nil/undef: `undef`
- Empty collections: `[]`, `{}`
- Arrays: `['a', 'b', 'c']` (no spaces around brackets to match puppet-strings format)
- Hashes: `{ 'key' => 'value' }` (spaces inside braces)
- Nested structures: Recursively converted

## Testing

### Unit Tests

Comprehensive test suite in `spec/unit/openvox-strings/hiera_spec.rb` covering:
- Hiera configuration loading
- Data file parsing
- All Puppet data types
- Nested structures
- Edge cases (missing files, wrong module names, etc.)
- Array formatting without spaces to match code defaults

### Integration Tests

Three-stage integration test in `slauger/puppet-github_actions_runner`:

1. **[Test 1 - Baseline (PR#4)](https://github.com/slauger/puppet-github_actions_runner/pull/4)**
   - Uses OLD openvox-strings (6.0.0 from RubyGems)
   - All defaults in code
   - Establishes baseline REFERENCE.md

2. **[Test 2 - Backwards Compatibility (PR#5)](https://github.com/slauger/puppet-github_actions_runner/pull/5)**
   - Uses NEW openvox-strings (this PR)
   - All defaults still in code
   - Proves 100% backwards compatibility

3. **[Test 3 - Full Hiera (PR#6)](https://github.com/slauger/puppet-github_actions_runner/pull/6)**
   - Uses NEW openvox-strings (this PR)
   - ALL defaults moved from code to `data/common.yaml`
   - Proves Hiera defaults feature works correctly

**Result**: All three tests produce byte-for-byte identical REFERENCE.md documentation.

### Test Data Types Covered

The integration tests validate all common Puppet data types:
- `Integer`: `42`
- `Float`: `3.14`
- `Array` (empty): `[]`
- `Array[String]`: `['alpha', 'beta', 'gamma']`
- `Array[Integer]`: `[1, 2, 3, 5, 8]`
- `Hash` (nested): `{ 'config' => { 'timeout' => 30, 'retry' => true }, 'tags' => ['prod', 'eu'] }`
- Plus all standard module parameters (Strings, Booleans, Optional types, etc.)

## Breaking Changes

None. This is a fully backwards-compatible addition:
- Modules without Hiera: No change in behavior
- Modules with Hiera but code defaults: Code defaults take precedence
- Only affects modules that use Hiera defaults WITHOUT code defaults

## Documentation

The implementation is self-documenting through:
- YARD documentation in code
- Comprehensive unit tests showing usage
- Integration test examples in real-world module

## Related Issues

This addresses the common pain point where modules using Hiera v5 data-in-modules pattern couldn't document their defaults properly.